### PR TITLE
Use bitcore-lib as a peerDependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 install:
+    # Install peerDependencies on > npm3
+    # When all dependencies declare bitcore-lib as a peerDependency this can be bumped up, but this matches the current ecosystem version expected by dependencies
+  - if [ $(npm --version | sed 's/\..*//g') -ge 3 ]; then npm install bitcore-lib@0.13.7; fi
   - npm install
-  - npm install bitcore-lib
 after_script:
   - gulp coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ before_install:
   - sh -e /etc/init.d/xvfb start
 install:
   - npm install
+  - npm install bitcore-lib
 after_script:
   - gulp coveralls

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gulp": "^3.8.10"
   },
   "peerDependencies": {
-    "bitcore-lib": "^0.14"
+    "bitcore-lib": "~0.13.7"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -22,14 +22,15 @@
     "type": "git",
     "url": "https://github.com/bitpay/bitcore-message.git"
   },
-  "dependencies": {
-    "bitcore-lib": "^0.13.7"
-  },
+  "dependencies": {},
   "devDependencies": {
     "bitcore-build": "bitpay/bitcore-build",
     "brfs": "^1.3.0",
     "chai": "~1.10.0",
     "gulp": "^3.8.10"
+  },
+  "peerDependencies": {
+    "bitcore-lib": "^0.14"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
One wrinkle to using the bitcore stack is the obvious need to have a singleton `bitcore-lib`.  The `bitcoin-lib` package hosts the `bitcoind` library and there are good reasons to not wanting to have multiple `bitcoind` instances running on the same machine.

However, I am not a fan of the runtime check and would rather have all packages be declaring `bitcoin-lib` in `peerDependencies`.  This way the enclosing package can specify whatever version of `bitcoin-lib` it wants and `npm` will inform user if there is an unmet dependency at _install_ time rather than _run_ time.

I have a working example of `bitcore-lib` running as a peerDependency at  [bitcore-docker-build](https://github.com/CaptEmulation/bitcore-docker-build) which is also running testnet at [bitcore.soapbubble.online/insight](https://bitcore.soapbubble.online/insight)

I also updated `bitcore-lib` to 0.14 because `bitcore-wallet-service` has already done so and I figured if it was good enough for `bitcoin-wallet-service` it's good enough for everything else :smile: 