### PR TITLE
package.json: bump bitcore-lib dep to 0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/bitpay/bitcore-message.git"
   },
   "dependencies": {
-    "bitcore-lib": "^0.13.7"
+    "bitcore-lib": "^0.14.0"
   },
   "devDependencies": {
     "bitcore-build": "bitpay/bitcore-build",


### PR DESCRIPTION
This fixes a runtime error when used with other bitcore components,
which have since already updated to require bitcore-lib 0.14.0.